### PR TITLE
Remove extraneous line from code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ long intersectionCardinality = combiner.intersectionCardinality(sketches);
 ### Serializing a sketch
 To get a byte[] representation of a sketch, use the `IntersectionSketch.SerDe` interface:
 ```
-HyperMinHash sketch = new
 HyperMinHashSerde serde = new HyperMinHashSerde();
 ```
 


### PR DESCRIPTION
Just removes a line that's not quite complete from the README