### PR TITLE
Update Integer.SIZE to Long.SIZE in BitHelper

### DIFF
--- a/src/main/java/com/liveramp/hyperminhash/BitHelper.java
+++ b/src/main/java/com/liveramp/hyperminhash/BitHelper.java
@@ -10,7 +10,7 @@ class BitHelper {
    */
   static long getLeftmostBits(long value, int numBits) {
     if (numBits >= Long.SIZE) {
-      throw new IllegalArgumentException(String.format("numBits must be < %d", Integer.SIZE));
+      throw new IllegalArgumentException(String.format("numBits must be < %d", Long.SIZE));
     }
 
     return (value >>> (Long.SIZE - numBits));


### PR DESCRIPTION
I believe the `getLeftmostBits` method of the `BitHelper` class should throw `IllegalArgumentException(String.format("numBits must be < %d", Long.SIZE))` instead of `IllegalArgumentException(String.format("numBits must be < %d", Integer.SIZE))` because the conditional checks `numBits` against `Long.SIZE` and not `Integer.SIZE`.