### PR TITLE
IMP optimize serde and union operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,14 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.0.0</version>
+            <!-- fix NullPointerException -->
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.8.1</version>
+              </dependency>
+            </dependencies>
             <executions>
               <execution>
                 <configuration>

--- a/src/main/java/com/liveramp/hyperminhash/BetaMinHash.java
+++ b/src/main/java/com/liveramp/hyperminhash/BetaMinHash.java
@@ -59,7 +59,7 @@ public class BetaMinHash implements IntersectionSketch<BetaMinHash> {
     }
 
     final short[] registersCopy = new short[NUM_REGISTERS];
-    System.arraycopy(registers, 0, registers, 0, NUM_REGISTERS);
+    System.arraycopy(registers, 0, registersCopy, 0, NUM_REGISTERS);
 
     return wrapRegisters(registersCopy);
   }

--- a/src/main/java/com/liveramp/hyperminhash/BetaMinHashCardinalityGetter.java
+++ b/src/main/java/com/liveramp/hyperminhash/BetaMinHashCardinalityGetter.java
@@ -9,7 +9,7 @@ class BetaMinHashCardinalityGetter {
     double zeros = saz.zeros;
     double mHat = (double) BetaMinHash.NUM_REGISTERS;
     double alpha = alpha(BetaMinHash.NUM_REGISTERS);
-    return (long) (alpha * mHat * (mHat - zeros) / (beta(zeros) + sum));
+    return Math.round(alpha * mHat * (mHat - zeros) / (beta(zeros) + sum));
   }
 
   private static SumAndZeros getRegisterSumAndZeros(BetaMinHash sketch) {

--- a/src/main/java/com/liveramp/hyperminhash/BetaMinHashCombiner.java
+++ b/src/main/java/com/liveramp/hyperminhash/BetaMinHashCombiner.java
@@ -1,6 +1,7 @@
 package com.liveramp.hyperminhash;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 public class BetaMinHashCombiner implements SketchCombiner<BetaMinHash> {
 
@@ -16,21 +17,17 @@ public class BetaMinHashCombiner implements SketchCombiner<BetaMinHash> {
 
   @Override
   public final BetaMinHash union(Collection<BetaMinHash> sketches) {
-    if (sketches.isEmpty()) {
+    Iterator<BetaMinHash> iter = sketches.iterator();
+    if (!iter.hasNext()) {
       throw new IllegalArgumentException("Input sketches cannot be empty.");
     }
 
-    final BetaMinHash firstSketch = sketches.stream()
-        .findFirst()
-        .get();
-    if (sketches.size() == 1) {
-      return firstSketch.deepCopy();
-    }
+    final BetaMinHash mergedSketch = iter.next().deepCopy();
 
-    final int numRegisters = firstSketch.registers.length;
-    final BetaMinHash mergedSketch = firstSketch.deepCopy();
-    for (int i = 0; i < numRegisters; i++) {
-      for (BetaMinHash sketch : sketches) {
+    final int numRegisters = mergedSketch.registers.length;
+    while (iter.hasNext()) {
+      final BetaMinHash sketch = iter.next();
+      for (int i = 0; i < numRegisters; i++) {
         mergedSketch.registers[i] = max(
             mergedSketch.registers[i],
             sketch.registers[i]

--- a/src/main/java/com/liveramp/hyperminhash/BetaMinHashCombiner.java
+++ b/src/main/java/com/liveramp/hyperminhash/BetaMinHashCombiner.java
@@ -60,15 +60,13 @@ public class BetaMinHashCombiner implements SketchCombiner<BetaMinHash> {
 
     long c = 0;
     long n = 0;
-    final BetaMinHash firstSketch = sketches.stream()
-        .findFirst()
-        .get();
-    for (int i = 0; i < firstSketch.registers.length; i++) {
-      if (firstSketch.registers[i] != 0) {
+    BetaMinHash[] sketchArray = sketches.toArray(new BetaMinHash[sketches.size()]);
+    for (int i = 0; i < sketchArray[0].registers.length; i++) {
+      if (sketchArray[0].registers[i] != 0) {
         boolean itemInIntersection = true;
-        for (BetaMinHash sketch : sketches) {
-          itemInIntersection =
-              itemInIntersection && firstSketch.registers[i] == sketch.registers[i];
+        for (int j = 1; j < sketchArray.length; j++) {
+          itemInIntersection = itemInIntersection
+                  && sketchArray[0].registers[i] == sketchArray[j].registers[i];
         }
 
         if (itemInIntersection) {

--- a/src/main/java/com/liveramp/hyperminhash/BetaMinHashSerde.java
+++ b/src/main/java/com/liveramp/hyperminhash/BetaMinHashSerde.java
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer;
 
 import static com.liveramp.hyperminhash.BetaMinHash.NUM_REGISTERS;
 
-public class BetaMinHashSerde implements IntersectionSketch.SerDe<BetaMinHash> {
+public class BetaMinHashSerde extends IntersectionSketch.SerDe<BetaMinHash> {
 
   /*
     Format:
@@ -14,9 +14,8 @@ public class BetaMinHashSerde implements IntersectionSketch.SerDe<BetaMinHash> {
       registers (NUM_REGISTERS * short)
    */
   @Override
-  public BetaMinHash fromBytes(byte[] bytes) {
+  public BetaMinHash readFrom(ByteBuffer inputBuffer) {
     short[] registers = new short[BetaMinHash.NUM_REGISTERS];
-    ByteBuffer inputBuffer = ByteBuffer.wrap(bytes);
 
     byte serdeToken = inputBuffer.get();
     if (!BetaMinHash.class.equals(SerializationTokens.getClassForToken(serdeToken).get())) {
@@ -44,8 +43,7 @@ public class BetaMinHashSerde implements IntersectionSketch.SerDe<BetaMinHash> {
   }
 
   @Override
-  public byte[] toBytes(BetaMinHash sketch) {
-    ByteBuffer byteBuffer = ByteBuffer.allocate(sizeInBytes(sketch));
+  public void writeTo(BetaMinHash sketch, ByteBuffer byteBuffer) {
     byteBuffer.put(SerializationTokens.getTokenForClass(BetaMinHash.class).get());
     byteBuffer.put(BetaMinHash.VERSION);
     for (short i = 0; i < sketch.registers.length;) {
@@ -62,7 +60,6 @@ public class BetaMinHashSerde implements IntersectionSketch.SerDe<BetaMinHash> {
         i++;
       }
     }
-    return byteBuffer.array();
   }
 
   @Override

--- a/src/main/java/com/liveramp/hyperminhash/HyperMinHashCombiner.java
+++ b/src/main/java/com/liveramp/hyperminhash/HyperMinHashCombiner.java
@@ -56,14 +56,14 @@ public class HyperMinHashCombiner implements SketchCombiner<HyperMinHash> {
 
     long c = 0;
     long n = 0;
-    final HyperMinHash firstSketch = sketches.stream().findFirst().get();
-    long numRegisters = firstSketch.registers.getNumRegisters();
+    HyperMinHash[] sketchArray = sketches.toArray(new HyperMinHash[sketches.size()]);
+    long numRegisters = sketchArray[0].registers.getNumRegisters();
     for (int i = 0; i < numRegisters; i++) {
-      if (firstSketch.registers.getRegisterAtIndex(i) != 0) {
+      if (sketchArray[0].registers.getRegisterAtIndex(i) != 0) {
         boolean itemInIntersection = true;
-        for (HyperMinHash sketch : sketches) {
+        for (int j = 1; j < sketchArray.length; j++) {
           itemInIntersection = itemInIntersection &&
-              firstSketch.registers.getMantissaAtRegister(i) == sketch.registers
+                  sketchArray[0].registers.getMantissaAtRegister(i) == sketchArray[j].registers
                   .getMantissaAtRegister(i);
         }
 

--- a/src/main/java/com/liveramp/hyperminhash/HyperMinHashCombiner.java
+++ b/src/main/java/com/liveramp/hyperminhash/HyperMinHashCombiner.java
@@ -1,6 +1,7 @@
 package com.liveramp.hyperminhash;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 public class HyperMinHashCombiner implements SketchCombiner<HyperMinHash> {
 
@@ -17,17 +18,14 @@ public class HyperMinHashCombiner implements SketchCombiner<HyperMinHash> {
   public HyperMinHash union(Collection<HyperMinHash> sketches) {
     assertInputNotEmpty(sketches);
     assertParamsAreEqual(sketches);
-    final HyperMinHash firstSketch = sketches.stream().findFirst().get();
-    if (sketches.size() == 1) {
-      return firstSketch.deepCopy();
-    }
+    Iterator<HyperMinHash> iter = sketches.iterator();
 
-    final int numRegisters = firstSketch.registers.getNumRegisters();
-    final HyperMinHash mergedSketch = firstSketch.deepCopy();
+    final HyperMinHash mergedSketch = iter.next().deepCopy();
+    final int numRegisters = mergedSketch.registers.getNumRegisters();
 
-    for (int i = 0; i < numRegisters; i++) {
-      for (HyperMinHash sketch : sketches) {
-
+    while (iter.hasNext()) {
+      final HyperMinHash sketch = iter.next();
+      for (int i = 0; i < numRegisters; i++) {
         mergedSketch.registers.updateIfGreaterThan(i, sketch.registers.getRegisterAtIndex(i));
       }
     }

--- a/src/main/java/com/liveramp/hyperminhash/HyperMinHashSerDe.java
+++ b/src/main/java/com/liveramp/hyperminhash/HyperMinHashSerDe.java
@@ -2,9 +2,7 @@ package com.liveramp.hyperminhash;
 
 import java.nio.ByteBuffer;
 
-import static com.liveramp.hyperminhash.BetaMinHash.NUM_REGISTERS;
-
-public class HyperMinHashSerDe implements IntersectionSketch.SerDe<HyperMinHash> {
+public class HyperMinHashSerDe extends IntersectionSketch.SerDe<HyperMinHash> {
 
   /*
         Serialized format:
@@ -23,8 +21,7 @@ public class HyperMinHashSerDe implements IntersectionSketch.SerDe<HyperMinHash>
           for now.
    */
   @Override
-  public HyperMinHash fromBytes(byte[] bytes) {
-    ByteBuffer inputBuffer = ByteBuffer.wrap(bytes);
+  public HyperMinHash readFrom(ByteBuffer inputBuffer) {
     byte serdeToken = inputBuffer.get();
     if (!HyperMinHash.class.equals(SerializationTokens.getClassForToken(serdeToken).get())) {
       throw new IllegalArgumentException("Input bytes do not represent a HyperMinHash object!");
@@ -81,8 +78,7 @@ public class HyperMinHashSerDe implements IntersectionSketch.SerDe<HyperMinHash>
   }
 
   @Override
-  public byte[] toBytes(HyperMinHash sketch) {
-    ByteBuffer outputBuffer = ByteBuffer.allocate(sizeInBytes(sketch));
+  public void writeTo(HyperMinHash sketch, ByteBuffer outputBuffer) {
     outputBuffer.put(SerializationTokens.getTokenForClass(HyperMinHash.class).get());
     outputBuffer.put(HyperMinHash.VERSION);
     outputBuffer.putInt(sketch.p);
@@ -131,8 +127,6 @@ public class HyperMinHashSerDe implements IntersectionSketch.SerDe<HyperMinHash>
     } else {
       throw new IllegalArgumentException("Register type not supported: " + registersClass);
     }
-
-    return outputBuffer.array();
   }
 
   @Override

--- a/src/main/java/com/liveramp/hyperminhash/IntersectionSketch.java
+++ b/src/main/java/com/liveramp/hyperminhash/IntersectionSketch.java
@@ -1,5 +1,7 @@
 package com.liveramp.hyperminhash;
 
+import java.nio.ByteBuffer;
+
 /**
  * Representation of a set that is able to estimate the cardinality of that set, and perform the
  * operations in {@link SketchCombiner}. Each implementation of this interface should have a corresponding
@@ -33,19 +35,39 @@ public interface IntersectionSketch<T extends IntersectionSketch<T>> {
    *
    * @param <T> Intersection Sketch Type
    */
-  interface SerDe<T extends IntersectionSketch<T>> {
+  abstract class SerDe<T extends IntersectionSketch<T>> {
 
     /**
      * @param bytes serialized representation of the sketch.
      * @return deserialized sketch
      */
-    T fromBytes(byte[] bytes);
+    public T fromBytes(byte[] bytes) {
+      ByteBuffer inputBuffer = ByteBuffer.wrap(bytes);
+      return readFrom(inputBuffer);
+    }
+
+    /**
+     * @param buffer buffer containing serialized representation of the sketch.
+     * @return deserialized sketch
+     */
+    abstract public T readFrom(ByteBuffer buffer);
 
     /**
      * @param sketch the sketch to be serialized
      * @return serialized representation of the input sketch
      */
-    byte[] toBytes(T sketch);
+    public byte[] toBytes(T sketch) {
+      ByteBuffer outputBuffer = ByteBuffer.allocate(sizeInBytes(sketch));
+      writeTo(sketch, outputBuffer);
+      return outputBuffer.array();
+    }
+
+    /**
+     * @param sketch the sketch to be serialized
+     * @param buffer the buffer to write to
+     * @return serialized representation of the input sketch
+     */
+    abstract public void writeTo(T sketch, ByteBuffer buffer);
 
     /**
      * Returns the size of the serialized form of this sketch
@@ -53,6 +75,6 @@ public interface IntersectionSketch<T extends IntersectionSketch<T>> {
      * @param sketch the sketch whose size in bytes we want
      * @return size in bytes
      */
-    int sizeInBytes(T sketch);
+    public abstract int sizeInBytes(T sketch);
   }
 }


### PR DESCRIPTION
Serialization of sparse objects creates a lot of zeros, which becomes
costly in some applications when serialization is used as an
intermediate step while building up unions. The proposed scheme is
backwards-compatible with the current implementation, but also makes use
of negative values (which shouldn't be in the registers) to encode
run-lengths of zero values.

Also introduced here is an optimization for union operations, which
previously applied logic to the first sketch twice. To that end, a fix
to `deepCopy()` was also needed for `BetaMinHash`, whose `deepCopy`
never actually copied values.

Motivation:

We want to use this library in both spark and elasticsearch (as a
custom plugin); spark to create binary serialized forms and
elasticsearch to search/aggregate over them in realtime. Our Spark UDAF
necessarily has to create many sparse objects before merging them, and
this is made much more efficient in terms of runtime by finding a better
encoding scheme for such sparse objects. There is no penalty when
objects are "dense" (in terms of serialized size). Impact on
deserialization time is minimal; each value is checked for negativity.
Serialization now requires two passes: one to determine output size and
one to do the serialization.